### PR TITLE
Link llvm with -Wl,-Bsymbolic

### DIFF
--- a/src/rz-plugin/CMakeLists.txt
+++ b/src/rz-plugin/CMakeLists.txt
@@ -18,10 +18,11 @@ set(SOURCES
 add_library(core_retdec SHARED ${SOURCES})
 target_link_libraries(core_retdec PUBLIC retdec::config) # include dirs from here are used by the cutter plugin
 
-set(CORE_LIBS
-	retdec::retdec
-	Rizin::Core
-)
+set(CORE_LIBS Rizin::Core)
+if (UNIX AND NOT APPLE)
+	list(APPEND CORE_LIBS -Wl,-Bsymbolic)
+endif()
+list(APPEND CORE_LIBS retdec::retdec)
 if (MSVC)
 	list(APPEND CORE_LIBS
 		retdec::bin2llvmir -WHOLEARCHIVE:$<TARGET_FILE_NAME:retdec::bin2llvmir>


### PR DESCRIPTION
When another llvm was already loaded at core_retdec.so load time, the
symbols in it would be bound to that first llvm instead of using the
ones inside the plugin itself.
This change makes sure they are not resolved dynamically anymore.