### PR TITLE
Fix compatibility with rizin 0.7.3 (#29)

### DIFF
--- a/src/rz-plugin/data.cpp
+++ b/src/rz-plugin/data.cpp
@@ -161,7 +161,7 @@ Function RizinDatabase::fetchSeekedFunction() const
  */
 void RizinDatabase::fetchFunctionsAndGlobals(Config &rzconfig) const
 {
-	auto list = rz_analysis_get_fcns(_rzcore.analysis);
+	auto list = rz_analysis_function_list(_rzcore.analysis);
 	if (list != nullptr) {
 		FunctionContainer functions;
 		for (RzListIter *it = list->head; it; it = rz_list_iter_get_next(it)) {


### PR DESCRIPTION
The upstream PR rizinorg/rizin#4353 removed the `rz_analysis_get_fcns` function due to its duplication with `rz_analysis_function_list`. This change caused incompatibilities(#29) in `RizinDatabase::fetchFunctionsAndGlobals`, which relied on the removed function.

Fix #29