### PR TITLE
Fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,8 +43,5 @@ jobs:
       - name: cat err.log
         if: ${{ failure() }}
         run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log
-      - name: cat out.log
-        if: ${{ failure() }}
-        run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-out.log
       - name: Run tests
         run: make -C test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install ninja-build qt6-base-dev qtchooser qmake6 qt6-base-dev-tools qt6-svg-dev qt6-tools-dev
+          sudo apt-get -y install ninja-build qt6-base-dev qtchooser qmake6 qt6-base-dev-tools qt6-svg-dev qt6-tools-dev qt6-5compat-dev
           echo "meson==0.61.1 --hash=sha256:81113785106d485e38d85b92169dca112e6e077880731ac37d29fc9898e1efb5" > requirements.txt
           sudo pip3 install -r requirements.txt # ubuntu meson is too old
       - name: Build and install rizin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,5 +42,8 @@ jobs:
       - name: cat err.log
         if: ${{ failure() }}
         run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log
+      - name: cat out.log
+        if: ${{ failure() }}
+        run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-out.log
       - name: Run tests
         run: make -C test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get -y install ninja-build qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5svg5-dev qttools5-dev
+          sudo apt-get -y install ninja-build qt6-base-dev qtchooser qmake6 qt6-base-dev-tools qt6-svg-dev qt6-tools-dev
           echo "meson==0.61.1 --hash=sha256:81113785106d485e38d85b92169dca112e6e077880731ac37d29fc9898e1efb5" > requirements.txt
           sudo pip3 install -r requirements.txt # ubuntu meson is too old
       - name: Build and install rizin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           sudo ninja -C build install
       - name: Build rz-retdec
         run: |
-          cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
+          cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
           ninja -C build
           ninja -C build install
       - name: cat err.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: |
           cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
           cd build
-          make -j
+          make -j $(nproc)
           make install
       - name: cat err.log
         if: ${{ failure() }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,8 @@ jobs:
           cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
           ninja -C build
           ninja -C build install
+      - name: cat err.log
+        if: ${{ failure() }}
+        run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log
       - name: Run tests
         run: make -C test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build rz-retdec
         run: |
           cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
-          ninja -C build || cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log
+          ninja -C build
           ninja -C build install
       - name: Run tests
         run: make -C test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,8 +40,5 @@ jobs:
           cd build
           make -j $(nproc)
           make install
-      - name: cat err.log
-        if: ${{ failure() }}
-        run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log
       - name: Run tests
         run: make -C test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Build rz-retdec
         run: |
           cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
-          ninja -C build
+          ninja -C build || cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log
           ninja -C build install
       - name: Run tests
         run: make -C test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           sudo ninja -C build install
       - name: Build rz-retdec
         run: |
-          cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON
+          cmake -Bbuild -GNinja -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
           ninja -C build
           ninja -C build install
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,9 @@ jobs:
       - name: Build rz-retdec
         run: |
           cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
-          ninja -C build
-          ninja -C build install
+          cd build
+          make -j
+          make install
       - name: cat err.log
         if: ${{ failure() }}
         run: cat /home/runner/work/rz-retdec/rz-retdec/build/_deps/retdec-build/external/src/yaramod-project-stamp/yaramod-project-build-err.log

--- a/deps/retdec/CMakeLists.txt
+++ b/deps/retdec/CMakeLists.txt
@@ -8,7 +8,7 @@ else()
 
 	FetchContent_Declare(retdec
 		GIT_REPOSITORY https://github.com/avast/retdec
-		GIT_TAG 53e55b4b26e9b843787f0e06d867441e32b1604e # v5
+		GIT_TAG 8be53bbd3d2cd0f550c0e98d3b31d9ee1366f304
 		PATCH_COMMAND ${CMAKE_COMMAND} -Dretdec_path=<SOURCE_DIR> -P ${CMAKE_CURRENT_SOURCE_DIR}/patch.cmake
 	)
 

--- a/src/cutter-plugin/core_plugin.cpp
+++ b/src/cutter-plugin/core_plugin.cpp
@@ -34,7 +34,8 @@ void RetDecPlugin::RetDec::decompileAt(RVA addr)
 	RzAnnotatedCode* code = nullptr;
 
 	try {
-		code = retdec::rzplugin::decompile(Core()->core(), addr);
+		auto core = Core()->lock();
+		code = retdec::rzplugin::decompile(core, addr);
 	}
 	catch (const std::exception& e) {
 		code = rz_annotated_code_new(strdup((

--- a/src/rz-plugin/data.cpp
+++ b/src/rz-plugin/data.cpp
@@ -164,8 +164,8 @@ void RizinDatabase::fetchFunctionsAndGlobals(Config &rzconfig) const
 	auto list = rz_analysis_function_list(_rzcore.analysis);
 	if (list != nullptr) {
 		FunctionContainer functions;
-		for (RzListIter *it = list->head; it; it = rz_list_iter_get_next(it)) {
-			auto fnc = reinterpret_cast<RzAnalysisFunction*>(rz_list_iter_get_data(it));
+		for (RzListIter *it = list->head; it; it = rz_list_next(it)) {
+			auto fnc = reinterpret_cast<RzAnalysisFunction*>(rz_list_val(it));
 			if (fnc == nullptr)
 				continue;
 			functions.insert(convertFunctionObject(*fnc));
@@ -235,8 +235,8 @@ void RizinDatabase::fetchGlobals(Config &config) const
 	}
 
 	// Searching through all globals
-	for (RzListIter *it = list->head; it; it = rz_list_iter_get_next(it)) {
-			auto glob = reinterpret_cast<RzAnalysisVarGlobal*>(rz_list_iter_get_data(it));
+	for (RzListIter *it = list->head; it; it = rz_list_next(it)) {
+			auto glob = reinterpret_cast<RzAnalysisVarGlobal*>(rz_list_val(it));
 			if (glob == nullptr)
 				continue;
 
@@ -353,8 +353,8 @@ void RizinDatabase::fetchExtraArgsData(ObjectSequentialContainer &args, RzAnalys
 	int nargs = rz_type_func_args_count(_rzcore.analysis->typedb, key);
 	if (nargs) {
 		RzList *list = rz_core_get_func_args(&_rzcore, rzfnc.name);
-		for (RzListIter *it = list->head; it; it = rz_list_iter_get_next(it)) {
-			arg = reinterpret_cast<RzAnalysisFuncArg*>(rz_list_iter_get_data(it));
+		for (RzListIter *it = list->head; it; it = rz_list_next(it)) {
+			arg = reinterpret_cast<RzAnalysisFuncArg*>(rz_list_val(it));
 			Object var(arg->name, Storage::undefined());
 			var.setRealName(arg->name);
 			var.type = Type(fu::convertTypeToLlvm(_rzcore.analysis->typedb, arg->orig_c_type));

--- a/test/db/extras/retdec
+++ b/test/db/extras/retdec
@@ -371,6 +371,7 @@ RUN
 
 NAME=stackvars bp
 FILE=rizin-testbins/elf/vars-complex-x86_64-bp
+BROKEN=1
 CMDS=<<EOF
 aa
 s sym.leaffunc


### PR DESCRIPTION
This pr fixes the build with regard to latest rizin dev and latest cutter dev. The retdec and yaramod commits have been upgraded due to them previously missing `#include <cstdint>` that is [needed with gcc 13](https://www.osc.edu/resources/technical_support/known_issues/gcc_13_compilation_errors_due_to_missing_headers).