### PR TITLE
Remove yaramod override

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
           sudo ninja -C build install
       - name: Build rz-retdec
         run: |
-          cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON -DYARAMOD_URL="https://github.com/avast/yaramod/archive/refs/tags/v4.6.0.zip" -DYARAMOD_ARCHIVE_SHA256=cb43798e8d56d63a1c06ee2ac7af100e50f7be8d5f2785f26edb01c1704a44b5
+          cmake -Bbuild -DCMAKE_INSTALL_PREFIX=$HOME/.local -DBUILD_CUTTER_PLUGIN=ON
           cd build
           make -j $(nproc)
           make install


### PR DESCRIPTION
The pr removes the yaramod override since it apparently is not needed due to https://github.com/avast/retdec/commit/79d65efd82f7ea9e8c68cf9e47351a60bc850b21.